### PR TITLE
Use Content-Range rather than Content-Length to get file length

### DIFF
--- a/src/main.test.js
+++ b/src/main.test.js
@@ -13,13 +13,6 @@ import { LocalFile } from './testHelpers.js';
 
 // Set up for mocked network request handling with msw
 export const server = setupServer(
-  http.head('http://localhost:5173/examples/zipped/mixmas-jpeg.szi', async ({ request }) => {
-    const localFile = await LocalFile.create('./public/examples/zipped/mixmas-jpeg.szi');
-
-    const response = HttpResponse.text('');
-    response.headers.set('content-length', localFile.size);
-    return response;
-  }),
   http.get('http://localhost:5173/examples/zipped/mixmas-jpeg.szi', async ({ request }) => {
     const localFile = await LocalFile.create('./public/examples/zipped/mixmas-jpeg.szi');
 
@@ -31,7 +24,10 @@ export const server = setupServer(
       const end = parseInt(endStr, 10) + 1; //Range requests are *inclusive*
 
       const body = await localFile.fetchRange(start, end, undefined);
-      return new HttpResponse(body, { status: 206 });
+      return new HttpResponse(body, {
+        status: 206,
+        headers: { 'Content-Range': `bytes ${startStr}-${endStr}/${localFile.size}` },
+      });
     } else {
       return new HttpResponse(undefined, { status: 500 });
     }


### PR DESCRIPTION
The old method of making a HEAD request to the SZI file and assuming that the returned Content-Length header turned out to be unreliable. Browsers generally set the Accept-Encoding to allow compressed responses and servers that support compression will favour it, all other things being equal. This means that in the general case the Content-Length from the HEAD could well be the *compressed* length of the file, *not* the real length.

So, for files stored on some systems (notably Github pages), we ended up with the wrong chunk of data being returned when looking for the Central Directory, meaning that the code couldn't find any of the expected data, which caused it to error out.

It turns out that you can resolve this outside the browser by setting the Accept-Encoding header yourself, but inside the browser this is a "Forbidden Header", which can't be overridden, so this isn't an option for us.

Luckily, if you do a ranged GET request for a small fragment of the file *most* browsers set Accept-Encoding to "identity", which effectively forbids compression, and *most* servers will respond to Ranged requests with uncompressed responses containing a handy Content-Range header, whose value contains the total file length. This commit changes the code to use this mechanism instead, which should work in most situations.

However, there are still combinations of browser and server that won't work. Firefox doesn't set Accept-Encoding to "identity" for ranged requests, and the Github pages server responds with compressed response bodies even when faced with a ranged request. There doesn't seem to be anything reasonable we can do to fix this, other than warn folks that it's a possibility.