### PR TITLE
Add explanatory paragraph to demo page.

### DIFF
--- a/index.css
+++ b/index.css
@@ -12,6 +12,10 @@ section {
   max-width: 400px;
   margin: 16px;
 
+  p {
+    line-height: 1.2;
+  }
+
   &.head {
     max-width: 100%;
   }

--- a/index.html
+++ b/index.html
@@ -23,6 +23,16 @@
   <section class="head">
     <h1>OpenSeadragon SZITileSource demo</h1>
     <div id="version"></div>
+    <div>
+      <p>This plugin adds support for <a href="https://github.com/smartinmedia/SZI-Format">SZI</a> files to <a
+          href="https://openseadragon.github.io/">OpenSeadragon</a>. Full documentation can be found <a
+          href="https://github.com/sundogbio/szi-tile-source">at the Github
+          repo</a>. This page serves as QA/test for the library, against a
+        variety of SZI files of varying well-formedness. You can also <a
+          href="https://github.com/sundogbio/szi-tile-source/blob/main/index.html">view the source for this
+          page</a>.
+      </p>
+    </div>
   </section>
   <div class="layout">
     <section>


### PR DESCRIPTION
The OSD site is going to link to this demo page. Whilst this is mainly for QA/evaluation, it'd be good to have a paragraph to explain to anybody coming straight to Github Pages.