### PR TITLE
OSD 6.0.0 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ for furhter details on how these work, though note that setting `mode` to `no-co
 
 #### OSD Compatibility
 
-SziTileSource has been written to work with version 5.x.x of OSD, and tested against 5.0.0 and
-5.0.1.
+SziTileSource as originally written to work with version 5.x.x of OSD. It has been tested and tested against 5.0.0 and 5.0.1.
+
+It is also compatible with 6.0.0 - the next forthcoming release - and [its changes to the caching system and data pipeline](https://github.com/openseadragon/openseadragon/discussions/2637)
 
 #### The file
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "szi-tile-source",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "An OpenSeadragon TileSource for remotely hosted SZI files",
   "type": "module",
   "files": [

--- a/src/main.js
+++ b/src/main.js
@@ -78,7 +78,7 @@ export const enableSziTileSource = (OpenSeadragon) => {
       const image = new Image();
       image.onload = function () {
         resetImageHandlers();
-        context.finish(image, context.userData.request, null);
+        context.finish(image, context.userData.request, 'image');
       };
       image.onabort = image.onerror = function () {
         resetImageHandlers();


### PR DESCRIPTION
`szi-tile-source` didn't work with the new caching scheme in OSD 6.0.0 (what's in the `master` branch right now). Now it does.